### PR TITLE
Support AppVeyor for CI & enable CI testing

### DIFF
--- a/AspNetCore.Identity.DocumentDB.sln
+++ b/AspNetCore.Identity.DocumentDB.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		.travis.yml = .travis.yml
+		appveyor.yml = appveyor.yml
 		build.bat = build.bat
 		LICENSE = LICENSE
 		README.md = README.md

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,69 @@
+-
+  branches:
+    except:
+      - /feature\/.*/
+  # https://www.appveyor.com/docs/branches/#build-on-tags-github-gitlab-and-bitbucket-only
+  skip_tags: true
+  version: '0.2.0-beta-{build}'
+  configuration:
+  - Release
+  platform: Any CPU
+  environment:
+    # Don't report back to the mothership
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    GitHubAccessToken:
+      secure: InsertEncryptedStringHere
+  pull_requests:
+    do_not_increment_build_number: true
+  install:
+  - ps: Start-FileDownload 'https://aka.ms/documentdb-emulator' -FileName 'C:\DocumentDB.Emulator.msi'
+  - msiexec.exe /i C:\DocumentDB.Emulator.msi /quiet /qn /log install.log
+  - ps: >-
+      & "${env:ProgramFiles}\DocumentDB Emulator\DocumentDB.Emulator.exe"
+
+  before_build:
+  - ps: >-
+      appveyor-retry dotnet restore -v Minimal
+
+      echo "Building ${env:CONFIGURATION}: build ${env:APPVEYOR_BUILD_NUMBER}"
+  build_script:
+  - ps: dotnet build "src\AspNetCore.Identity.DocumentDB" -c ${env:CONFIGURATION} --version-suffix ${env:APPVEYOR_BUILD_NUMBER}
+
+  test_script:
+  - ps: dotnet test test\CoreTests -c ${env:CONFIGURATION}
+  - ps: dotnet test test\CoreIntegrationTests -c ${env:CONFIGURATION}
+
+  before_deploy:
+  - ps: dotnet pack src\AspNetCore.Identity.DocumentDB -c ${env:CONFIGURATION} -o artifacts --version-suffix ${env:APPVEYOR_BUILD_NUMBER}
+
+  # https://www.appveyor.com/docs/how-to/git-push/
+  - ps: git config --global credential.helper store
+  - ps: Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:GitHubAccessToken):x-oauth-basic@github.com`n"
+  - ps: git config --global user.email "appveyor@felschr.com"
+  - ps: git config --global user.name "AppVeyor"
+  - ps: >-
+      $GIT_TAG = Get-Content -Raw -Path src/AspNetCore.Identity.DocumentDB/project.json | ConvertFrom-Json | select -ExpandProperty version
+      $GIT_TAG = ${GIT_TAG} -replace ".{1}$"
+      $GIT_TAG = "${GIT_TAG}${env:APPVEYOR_BUILD_NUMBER}"
+  - ps: git tag $GIT_TAG -a -m "Generated tag from AppVeyor from build ${env:APPVEYOR_BUILD_VERSION}"
+  - ps: git push --tags
+  deploy:
+  # https://www.appveyor.com/docs/deployment/github/
+  - provider: GitHub
+    release: v$(appveyor_build_version)
+    description: ''
+    auth_token:
+      secure: InsertEncryptedStringHere
+    artifact: /artifacts\\.*\.nupkg/
+    draft: true
+    prerelease: true
+    on:
+      branch: netcore
+  # https://www.appveyor.com/docs/deployment/nuget/
+  - provider: NuGet
+    api_key:
+      secure: InsertEncryptedStringHere
+    skip_symbols: false
+    artifact: /artifacts\\.*\.nupkg/
+    on:
+      branch: netcore


### PR DESCRIPTION
AppVeyor is free for open source project and runs on a Windows Server VM.  It has Visual Studio 2015 installed and allows for other software install as needed for building and testing.  It also supports automatic deployment to NuGet and creates a release for GitHub.  

For this project I have installed the DocumentDB Emulator, and queue both unit and integration tests to run on CI.  If the tests fail then the build will fail.  If everything passes then it will create a tag and release on GitHub, and release to NuGet.

#### Some setup is still required!
1) Create AppVeyor project for AspNetCore.Identity.DocumentDB
2) Encrypt your NuGet api key and GitHub access key via https://ci.appveyor.com/tools/encrypt
3) Modify the `appveyor.yml` file and replace any instance of `InsertEncryptedStringHere` with the new string from AppVeyor.